### PR TITLE
chore: update readme with link to new repo location

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+This project has been moved to https://github.com/mongodb-js/compass/tree/master/packages/compass-app-stores
 # app-stores [![][travis_img]][travis_url]
 
 > The external stores repo for compass


### PR DESCRIPTION
How does this look as the message we add to past repos READMEs? - adding the one line at the top in the screenshot? Would it be better to just link to the main compass repo since things might change down the line? (except for compass-aggregations, compass-crud, and compass-serverstats which are probably better to direct link since they’re shared repos and probably not changing too soon)

`master` branch will be automatically redirected to `main` by github if we end up renaming it.

<img width="1141" alt="Screen Shot 2021-05-14 at 4 38 52 PM" src="https://user-images.githubusercontent.com/1791149/118328422-f5cec500-b4d3-11eb-8490-48261e4bc43e.png">
